### PR TITLE
feat: in-memory TTL caching layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,8 @@ Thumbs.db
 # =====================
 backend/uploads
 uploads
+
+# =====================
+# Internal QA agent (local only — not for GitHub)
+# =====================
+.local-qa/

--- a/backend/ai_engine/crew.py
+++ b/backend/ai_engine/crew.py
@@ -154,9 +154,15 @@ def run_dataset_analysis(dataset_id: str) -> dict:
     from cache.cache_manager import get_cached_analysis, set_cached_analysis
 
     cached = get_cached_analysis(dataset_id)
-    if cached:
+    if cached is not None:
         print(f"[Ascendly] Cache HIT for dataset {dataset_id} — skipping pipeline.")
-        return cached
+        return {
+            **cached,
+            "request_id": str(uuid.uuid4()),           # fresh per-request ID
+            "cached": True,
+            "metadata": {**cached.get("metadata", {}), "processing_time_ms": 0},
+            "agent_logs": [],                          # no logs on cache hit
+        }
 
     start_time = time.time()
     request_id = str(uuid.uuid4())
@@ -181,7 +187,9 @@ def run_dataset_analysis(dataset_id: str) -> dict:
         {"agent_name": "Strategist", "output": strategist_output},
     ]
 
-    set_cached_analysis(dataset_id, response)
+    # Strip per-request volatile fields before caching — they are regenerated on cache hit
+    cacheable = {k: v for k, v in response.items() if k not in ("request_id", "agent_logs")}
+    set_cached_analysis(dataset_id, cacheable)
     return response
 
 

--- a/backend/ai_engine/crew.py
+++ b/backend/ai_engine/crew.py
@@ -148,8 +148,16 @@ def run_strategist_step(analyst_output: str, forecast_output: str) -> str:
 def run_dataset_analysis(dataset_id: str) -> dict:
     """
     Run the full AI analysis pipeline on a dataset stored in Supabase.
-    Calls each step function in sequence and returns structured results.
+    Checks in-memory cache first — returns immediately on hit.
+    Calls each step function in sequence and caches the result on miss.
     """
+    from cache.cache_manager import get_cached_analysis, set_cached_analysis
+
+    cached = get_cached_analysis(dataset_id)
+    if cached:
+        print(f"[Ascendly] Cache HIT for dataset {dataset_id} — skipping pipeline.")
+        return cached
+
     start_time = time.time()
     request_id = str(uuid.uuid4())
 
@@ -172,6 +180,8 @@ def run_dataset_analysis(dataset_id: str) -> dict:
         {"agent_name": "Forecaster", "output": forecast_output},
         {"agent_name": "Strategist", "output": strategist_output},
     ]
+
+    set_cached_analysis(dataset_id, response)
     return response
 
 

--- a/backend/ai_engine/tools/benchmark_tool.py
+++ b/backend/ai_engine/tools/benchmark_tool.py
@@ -28,6 +28,7 @@ def query_benchmarks(category: str) -> str:
       query_benchmarks("competitor")
     """
     try:
+        from cache.cache_manager import get_cached_benchmark, set_cached_benchmark
         from database.supabase_client import get_records
 
         valid_categories = ("industry_growth", "competitor")
@@ -35,6 +36,12 @@ def query_benchmarks(category: str) -> str:
             return json.dumps({
                 "error": f"Invalid category '{category}'. Must be one of: {valid_categories}"
             })
+
+        # Return from cache if available (TTL managed by cache_manager — 24h)
+        cached = get_cached_benchmark(category)
+        if cached:
+            print(f"[Ascendly] Benchmark cache HIT for category='{category}'")
+            return cached
 
         response = get_records("benchmarks", {"category": category})
         rows = response.data if response and response.data else []
@@ -45,7 +52,6 @@ def query_benchmarks(category: str) -> str:
                            "The benchmarks table may not be populated yet."
             })
 
-        # Return clean, agent-readable records
         benchmarks = [
             {
                 "name": r.get("name"),
@@ -58,7 +64,9 @@ def query_benchmarks(category: str) -> str:
             for r in rows
         ]
 
-        return json.dumps(benchmarks, indent=2)
+        result = json.dumps(benchmarks, indent=2)
+        set_cached_benchmark(category, result)
+        return result
 
     except Exception as e:
         return json.dumps({"error": f"Failed to query benchmarks: {str(e)}"})

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -134,11 +134,14 @@ async def _stream_quick_response(
     try:
         from cache.cache_manager import get_cached_chat, set_cached_chat
 
-        cached = get_cached_chat(message, dataset_id)
-        if cached:
-            yield _sse({"type": "token", "content": cached})
-            yield _sse({"type": "done", "message_id": str(uuid.uuid4()), "cached": True})
-            return
+        # Only cache stateless requests — skip when history is present (context-dependent)
+        use_cache = not history
+        if use_cache:
+            cached = get_cached_chat(message, user_id, dataset_id)
+            if cached is not None:
+                yield _sse({"type": "token", "content": cached})
+                yield _sse({"type": "done", "message_id": str(uuid.uuid4()), "cached": True})
+                return
 
         import litellm
 
@@ -189,7 +192,8 @@ async def _stream_quick_response(
                 yield _sse({"type": "token", "content": token})
 
         message_id = str(uuid.uuid4())
-        set_cached_chat(message, dataset_id, full_text)
+        if use_cache:
+            set_cached_chat(message, user_id, dataset_id, full_text)
         yield _sse({"type": "done", "message_id": message_id})
 
         # Log after stream completes

--- a/backend/app/api/endpoints/chat.py
+++ b/backend/app/api/endpoints/chat.py
@@ -132,6 +132,14 @@ async def _stream_quick_response(
 ):
     """Stream quick conversational response token by token."""
     try:
+        from cache.cache_manager import get_cached_chat, set_cached_chat
+
+        cached = get_cached_chat(message, dataset_id)
+        if cached:
+            yield _sse({"type": "token", "content": cached})
+            yield _sse({"type": "done", "message_id": str(uuid.uuid4()), "cached": True})
+            return
+
         import litellm
 
         model = os.getenv("CREWAI_LLM_MODEL", "azure/gpt-4o")
@@ -181,6 +189,7 @@ async def _stream_quick_response(
                 yield _sse({"type": "token", "content": token})
 
         message_id = str(uuid.uuid4())
+        set_cached_chat(message, dataset_id, full_text)
         yield _sse({"type": "done", "message_id": message_id})
 
         # Log after stream completes

--- a/backend/cache/cache_manager.py
+++ b/backend/cache/cache_manager.py
@@ -13,6 +13,7 @@ TODO (when Supabase columns are ready):
   - Persist benchmark results to benchmarks.fetched_at / benchmarks.ttl_hours columns
 """
 import hashlib
+import threading
 from cachetools import TTLCache
 
 # Max entries, TTL in seconds
@@ -20,54 +21,66 @@ _analysis_cache: TTLCache = TTLCache(maxsize=100, ttl=3600)       # 1 hour
 _chat_cache: TTLCache = TTLCache(maxsize=500, ttl=900)            # 15 minutes
 _benchmark_cache: TTLCache = TTLCache(maxsize=50, ttl=86400)      # 24 hours
 
+# RLocks — TTLCache is not thread-safe; asyncio.to_thread + uvicorn workers can race
+_analysis_lock = threading.RLock()
+_chat_lock = threading.RLock()
+_benchmark_lock = threading.RLock()
+
 
 # ── Analysis cache ────────────────────────────────────────────────────────────
 
 def get_cached_analysis(dataset_id: str) -> dict | None:
     """Return cached analysis result for a dataset, or None if not cached / expired."""
-    return _analysis_cache.get(dataset_id)
+    with _analysis_lock:
+        return _analysis_cache.get(dataset_id)
 
 
 def set_cached_analysis(dataset_id: str, result: dict) -> None:
     """Store analysis result in cache."""
-    _analysis_cache[dataset_id] = result
+    with _analysis_lock:
+        _analysis_cache[dataset_id] = result
 
 
 # ── Chat cache ────────────────────────────────────────────────────────────────
 
-def make_chat_key(message: str, dataset_id: str | None) -> str:
-    """SHA-256 hash of message + dataset_id used as cache key."""
-    raw = f"{message}:{dataset_id or ''}"
+def make_chat_key(message: str, user_id: str, dataset_id: str | None) -> str:
+    """SHA-256 hash of user_id + message + dataset_id used as cache key."""
+    raw = f"{user_id}:{message}:{dataset_id or ''}"
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
-def get_cached_chat(message: str, dataset_id: str | None) -> str | None:
+def get_cached_chat(message: str, user_id: str, dataset_id: str | None) -> str | None:
     """Return cached chat response, or None if not cached / expired."""
-    return _chat_cache.get(make_chat_key(message, dataset_id))
+    with _chat_lock:
+        return _chat_cache.get(make_chat_key(message, user_id, dataset_id))
 
 
-def set_cached_chat(message: str, dataset_id: str | None, response: str) -> None:
+def set_cached_chat(message: str, user_id: str, dataset_id: str | None, response: str) -> None:
     """Store chat response in cache."""
-    _chat_cache[make_chat_key(message, dataset_id)] = response
+    with _chat_lock:
+        _chat_cache[make_chat_key(message, user_id, dataset_id)] = response
 
 
 # ── Benchmark cache ───────────────────────────────────────────────────────────
 
 def get_cached_benchmark(category: str) -> str | None:
     """Return cached benchmark JSON string, or None if not cached / expired."""
-    return _benchmark_cache.get(category)
+    with _benchmark_lock:
+        return _benchmark_cache.get(category)
 
 
 def set_cached_benchmark(category: str, result: str) -> None:
     """Store benchmark JSON string in cache."""
-    _benchmark_cache[category] = result
+    with _benchmark_lock:
+        _benchmark_cache[category] = result
 
 
 # ── Cache stats (useful for debugging) ───────────────────────────────────────
 
 def cache_stats() -> dict:
-    return {
-        "analysis": {"size": len(_analysis_cache), "maxsize": _analysis_cache.maxsize, "ttl": _analysis_cache.ttl},
-        "chat":     {"size": len(_chat_cache),     "maxsize": _chat_cache.maxsize,     "ttl": _chat_cache.ttl},
-        "benchmark":{"size": len(_benchmark_cache),"maxsize": _benchmark_cache.maxsize,"ttl": _benchmark_cache.ttl},
-    }
+    with _analysis_lock, _chat_lock, _benchmark_lock:
+        return {
+            "analysis":  {"size": len(_analysis_cache),  "maxsize": _analysis_cache.maxsize,  "ttl": _analysis_cache.ttl},
+            "chat":      {"size": len(_chat_cache),      "maxsize": _chat_cache.maxsize,      "ttl": _chat_cache.ttl},
+            "benchmark": {"size": len(_benchmark_cache), "maxsize": _benchmark_cache.maxsize, "ttl": _benchmark_cache.ttl},
+        }

--- a/backend/cache/cache_manager.py
+++ b/backend/cache/cache_manager.py
@@ -1,0 +1,73 @@
+"""
+Cache Manager — in-memory TTL caches for analysis results, chat responses, and benchmark data.
+
+Three independent caches:
+  - analysis_cache   : full 3-agent pipeline results keyed by dataset_id (TTL: 1 hour)
+  - chat_cache       : quick litellm responses keyed by sha256(message + dataset_id) (TTL: 15 min)
+  - benchmark_cache  : benchmark query results keyed by category (TTL: 24 hours)
+
+All caches are in-memory only. They reset on server restart.
+
+TODO (when Supabase columns are ready):
+  - Persist analysis results to ai_insights table on cache miss, read back on hit
+  - Persist benchmark results to benchmarks.fetched_at / benchmarks.ttl_hours columns
+"""
+import hashlib
+from cachetools import TTLCache
+
+# Max entries, TTL in seconds
+_analysis_cache: TTLCache = TTLCache(maxsize=100, ttl=3600)       # 1 hour
+_chat_cache: TTLCache = TTLCache(maxsize=500, ttl=900)            # 15 minutes
+_benchmark_cache: TTLCache = TTLCache(maxsize=50, ttl=86400)      # 24 hours
+
+
+# ── Analysis cache ────────────────────────────────────────────────────────────
+
+def get_cached_analysis(dataset_id: str) -> dict | None:
+    """Return cached analysis result for a dataset, or None if not cached / expired."""
+    return _analysis_cache.get(dataset_id)
+
+
+def set_cached_analysis(dataset_id: str, result: dict) -> None:
+    """Store analysis result in cache."""
+    _analysis_cache[dataset_id] = result
+
+
+# ── Chat cache ────────────────────────────────────────────────────────────────
+
+def make_chat_key(message: str, dataset_id: str | None) -> str:
+    """SHA-256 hash of message + dataset_id used as cache key."""
+    raw = f"{message}:{dataset_id or ''}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def get_cached_chat(message: str, dataset_id: str | None) -> str | None:
+    """Return cached chat response, or None if not cached / expired."""
+    return _chat_cache.get(make_chat_key(message, dataset_id))
+
+
+def set_cached_chat(message: str, dataset_id: str | None, response: str) -> None:
+    """Store chat response in cache."""
+    _chat_cache[make_chat_key(message, dataset_id)] = response
+
+
+# ── Benchmark cache ───────────────────────────────────────────────────────────
+
+def get_cached_benchmark(category: str) -> str | None:
+    """Return cached benchmark JSON string, or None if not cached / expired."""
+    return _benchmark_cache.get(category)
+
+
+def set_cached_benchmark(category: str, result: str) -> None:
+    """Store benchmark JSON string in cache."""
+    _benchmark_cache[category] = result
+
+
+# ── Cache stats (useful for debugging) ───────────────────────────────────────
+
+def cache_stats() -> dict:
+    return {
+        "analysis": {"size": len(_analysis_cache), "maxsize": _analysis_cache.maxsize, "ttl": _analysis_cache.ttl},
+        "chat":     {"size": len(_chat_cache),     "maxsize": _chat_cache.maxsize,     "ttl": _chat_cache.ttl},
+        "benchmark":{"size": len(_benchmark_cache),"maxsize": _benchmark_cache.maxsize,"ttl": _benchmark_cache.ttl},
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ statsmodels
 python-multipart
 litellm
 azure-ai-inference>=1.0.0b9
+cachetools


### PR DESCRIPTION
## Summary

- Adds a 3-layer in-memory TTL cache (`cache/cache_manager.py`) using `cachetools` to avoid redundant AI pipeline runs
- Wraps the full 3-agent CrewAI pipeline (`run_dataset_analysis`) — cache hit skips the entire ~2-4 min pipeline
- Adds SHA-256 keyed response cache for quick litellm chat calls — identical questions return instantly
- Adds TTL cache for benchmark Supabase queries — repeated strategy calls skip the DB round-trip
- Hooks up pre-commit QA agent (local only, gitignored) that runs 7 checks before every commit

## Cache TTLs

| Cache | Key | TTL |
|-------|-----|-----|
| Analysis | `dataset_id` | 1 hour |
| Chat | `sha256(message + dataset_id)` | 15 minutes |
| Benchmark | `category` | 24 hours |

## Files Changed

| File | Change |
|------|--------|
| `backend/cache/cache_manager.py` | New — TTLCache instances + get/set helpers |
| `backend/cache/__init__.py` | New — package init |
| `backend/ai_engine/crew.py` | Wrap `run_dataset_analysis()` with cache check/set |
| `backend/app/api/endpoints/chat.py` | Add cache check/set in `_stream_quick_response()` |
| `backend/ai_engine/tools/benchmark_tool.py` | Add benchmark TTL cache check/set |
| `backend/requirements.txt` | Add `cachetools` |
| `.gitignore` | Add `.local-qa/` (internal QA agent, local only) |

## Notes

- All caches are in-memory only — reset on server restart
- Persistent caching (Supabase `ai_insights` + `benchmarks.fetched_at`) is stubbed with TODO comments, ready to wire in once DB columns are added
- Cache hit for analysis logs `[Ascendly] Cache HIT for dataset {id}` to server console
- Cached chat responses are returned as a single token event with `"cached": true` flag in the done event

## Test Plan
- [x] Start backend — confirm server starts clean with no import errors
- [ ] Run an analysis twice on the same dataset — second run should return immediately (check console for `Cache HIT`)
- [ ] Send the same chat message twice — second response should be instant
- [ ] Confirm `.local-qa/` folder does not appear in this PR diff