### PR TITLE
Feat/arize phoenix eval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,114 @@
+name: CI + CD — Deploy to Azure
+
+on:
+  push:
+    branches: ["Main"]
+
+jobs:
+  # ── 1. Backend Tests (deterministic only — no LLM cost) ───────────────────
+  backend-test:
+    name: pytest (deterministic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('backend/requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        working-directory: backend
+        run: pip install --upgrade pip && pip install -r requirements.txt
+
+      - name: Run deterministic tests
+        working-directory: backend
+        env:
+          PHOENIX_ENABLED: "false"
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+          SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
+        run: |
+          pytest tests/test_analyst_agent.py tests/test_forecaster_mape.py \
+            -v --tb=short --no-header -p no:warnings
+
+  # ── 2. Frontend Lint + Build ──────────────────────────────────────────────
+  frontend-build:
+    name: Lint + Build frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        env:
+          VITE_API_URL: ${{ secrets.VITE_API_URL }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        run: npm run build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist/
+          retention-days: 1
+
+  # ── 3. Deploy Backend → Azure App Service ────────────────────────────────
+  deploy-backend:
+    name: Deploy FastAPI → Azure App Service
+    runs-on: ubuntu-latest
+    needs: [backend-test, frontend-build]
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ascendly-backend
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ./backend
+
+  # ── 4. Deploy Frontend → Azure Static Web Apps ───────────────────────────
+  deploy-frontend:
+    name: Deploy React → Azure Static Web Apps
+    runs-on: ubuntu-latest
+    needs: [backend-test, frontend-build]
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "frontend"
+          output_location: "dist"
+          skip_app_build: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
 # =====================
+# Git Worktrees
+# =====================
+.worktrees/
+
+# =====================
 # Node / Frontend
 # =====================
 node_modules
@@ -77,6 +82,11 @@ git_status.txt
 # Internal QA agent (local only)
 # =====================
 .local-qa/
+
+# =====================
+# Claude sessions / local agents (local only)
+# =====================
+.claude-sessions/
 
 # =====================
 # Dev / debug scripts (local only)

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from app.api.insights import router as insights_router
 # from app.api.endpoints.patent_firm import router as patent_firm_router
 from app.api.endpoints.subscription import router as subscription_router
 from app.api.endpoints.tier_suggestion import router as tier_suggestion_router
+from app.api.endpoints.conversations import router as conversations_router
 from observability.tracing import init_tracing
 
 app = FastAPI(
@@ -30,10 +31,14 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORS — allow Vite frontend dev server (port 5173, etc)
+# CORS — allow local dev + Azure Static Web Apps production domain
+ALLOWED_ORIGIN_REGEX = (
+    r"^https?://(localhost|127\.0\.0\.1|\[::1\]|192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+)(:\d+)?$"
+    r"|^https://[a-z0-9-]+\.azurestaticapps\.net$"
+)
 app.add_middleware(
     CORSMiddleware,
-    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1|\[::1\]|192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+)(:\d+)?$",
+    allow_origin_regex=ALLOWED_ORIGIN_REGEX,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -48,6 +53,7 @@ app.include_router(insights_router)
 # app.include_router(patent_firm_router)
 app.include_router(subscription_router)
 app.include_router(tier_suggestion_router)
+app.include_router(conversations_router)
 
 
 # ============ SCHEMAS ============
@@ -456,4 +462,4 @@ async def get_dashboard_metrics(current_user=Depends(require_auth)):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,7 +5,9 @@ import {
   Navigate,
 } from "react-router-dom";
 import { AuthProvider } from "./context/AuthContext";
+import { useAuth } from "./context/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
+import { getRoleDashboardRoute } from "./utils/auth";
 
 import Login from './pages/auth/Login';
 import Register from './pages/auth/Register';
@@ -41,6 +43,11 @@ import PatentFirmClients from "./pages/patent-firm/Clients";
 import Applications from "./pages/patent-firm/Applications";
 import PatentFirmPayments from "./pages/patent-firm/Payments";
 
+function RoleBasedRedirect() {
+  const { user } = useAuth();
+  return <Navigate to={getRoleDashboardRoute(user?.role)} replace />;
+}
+
 function App() {
   return (
     <AuthProvider>
@@ -70,7 +77,7 @@ function App() {
               </ProtectedRoute>
             }
           >
-            <Route index element={<Navigate to="startup" replace />} />
+            <Route index element={<RoleBasedRedirect />} />
             <Route path="startup" element={<StartupDashboard />} />
             <Route path="patent" element={<PatentPage />} />
             <Route path="investors" element={<InvestorsPage />} />

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -235,11 +235,11 @@ export function getRoleDashboardRoute(role) {
     const r = role.toLowerCase();
     
     if (r.includes('startup') || r.includes('founder')) return '/dashboard/startup';
-    if (r.includes('investor')) return '/dashboard/investor';
+    if (r.includes('investor')) return '/dashboard/investors';
     if (r.includes('marketing') || r.includes('agency')) return '/dashboard/marketing-agency/projects';
     if (r.includes('patent')) return '/dashboard/patent-firm/dashboard';
-    if (r.includes('business') || r.includes('advisor')) return '/dashboard/advisor';
-    if (r.includes('admin')) return '/dashboard/admin';
+    if (r.includes('business') || r.includes('advisor')) return '/business-advisory';
+    if (r.includes('admin')) return '/dashboard/startup';
     
     // Default fallback
     return '/dashboard/startup';


### PR DESCRIPTION
## Summary                                                                                                                                                    

   - **Arize Phoenix evaluation** — full observability + test suite for CrewAI, Google ADK, and LiteLLM pipelines (`backend/ai_engine/`, `backend/tests/`)
   - **Azure CI/CD pipeline** — new `.github/workflows/deploy.yml` that runs deterministic tests, builds the frontend, and deploys both backend (Azure App
   Service) and frontend (Azure Static Web Apps) on every push to Main
   - **Role-based routing fix** — users now land on their correct dashboard after login based on registered role (investor → `/dashboard/investors`, business
   advisor → `/business-advisory`, admin → `/dashboard/startup`); `/dashboard` index redirect is now role-aware instead of hardcoded to startup
   - **CORS update** — backend now allows `*.azurestaticapps.net` for production frontend access
   - **Top bar & UI fixes** — top bar organised and icon fixes across all pages (from User branch)

   ## Test plan

   - [ ] Log in as Investor → lands on `/dashboard/investors`
   - [ ] Log in as Patent Firm → lands on `/dashboard/patent-firm/dashboard`
   - [ ] Log in as Business Advisor → lands on `/business-advisory`
   - [ ] Log in as Startup Founder → lands on `/dashboard/startup`
   - [ ] Navigate directly to `/dashboard` as any role → redirects correctly (not always startup)
   - [ ] GitHub Actions `CI + CD — Deploy to Azure` workflow appears in Actions tab after merge

   🤖 Generated with [Claude Code](https://claude.com/claude-code)
   EOF
   )" --base Main --head feat/arize-phoenix-eval