### PR TITLE
fix: enable patent firm router that was accidentally commented out

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -28,7 +28,7 @@ from app.api.endpoints.analysis import router as analysis_router
 from app.api.endpoints.dashboard import router as dashboard_router
 from app.api.endpoints.chat import router as chat_router
 from app.api.insights import router as insights_router
-# from app.api.endpoints.patent_firm import router as patent_firm_router
+from app.api.endpoints.patent_firm import router as patent_firm_router
 from app.api.endpoints.subscription import router as subscription_router
 from app.api.endpoints.tier_suggestion import router as tier_suggestion_router
 from app.api.endpoints.conversations import router as conversations_router
@@ -60,7 +60,7 @@ app.include_router(analysis_router)
 app.include_router(dashboard_router)
 app.include_router(chat_router)
 app.include_router(insights_router)
-# app.include_router(patent_firm_router)
+app.include_router(patent_firm_router)
 app.include_router(subscription_router)
 app.include_router(tier_suggestion_router)
 app.include_router(conversations_router)


### PR DESCRIPTION
## Summary
- `patent_firm_router` import and `app.include_router()` were both commented out in `main.py`
- This caused all `/api/patent-firm/*` endpoints to return 404
- Patent Firm dashboard showed "Failed to fetch dashboard stats" error
- All patent_firm Supabase tables exist and are ready

## Test plan
- [ ] Login as Patent Firm user on `app.ascendly.lk`
- [ ] Dashboard stats should load without error